### PR TITLE
Replace prefab-classes with ducktools-classbuilder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 readme="README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "prefab-classes",
+    "ducktools-classbuilder",
     "ducktools-lazyimporter",
     "ducktools-scriptmetadata",
     "ducktools-pythonfinder",

--- a/src/ducktools/envman/catalogue.py
+++ b/src/ducktools/envman/catalogue.py
@@ -25,8 +25,7 @@ from ducktools.lazyimporter import (
     MultiFromImport,
 )
 
-from prefab_classes import prefab, attribute
-import prefab_classes.funcs as prefab_funcs
+from ducktools.classbuilder.prefab import prefab, attribute, as_dict
 
 from .environment_spec import EnvironmentSpec
 from .config import Config
@@ -114,7 +113,7 @@ class CachedEnv:
 @prefab(kw_only=True)
 class Catalogue:
     caches: dict[str, CachedEnv]
-    config: Config
+    config: Config = attribute(in_dict=False)
     # Not the count of current envs
     # This is the total number of envs that have ever been created
     env_counter: int = 1
@@ -125,7 +124,7 @@ class Catalogue:
     def save(self) -> None:
         """Serialize this class into a JSON string and save"""
         # For external users that may not import prefab directly
-        data = prefab_funcs.to_json(self, excludes=("config",), indent=2)
+        data = _laz.json.dumps(self, default=as_dict, indent=2)
 
         os.makedirs(self.config.cache_folder, exist_ok=True)
 

--- a/src/ducktools/envman/config.py
+++ b/src/ducktools/envman/config.py
@@ -20,7 +20,7 @@ import os.path
 import datetime
 from _collections_abc import Callable
 
-from prefab_classes import prefab
+from ducktools.classbuilder.prefab import prefab
 
 from .exceptions import UnsupportedPlatformError
 

--- a/src/ducktools/envman/environment_spec.py
+++ b/src/ducktools/envman/environment_spec.py
@@ -18,7 +18,7 @@
 Handle parsing of inline script dependency data.
 """
 
-from prefab_classes import prefab
+from ducktools.classbuilder.prefab import prefab
 from ducktools.lazyimporter import (
     LazyImporter,
     TryExceptImport,

--- a/tests/test_environmentspec.py
+++ b/tests/test_environmentspec.py
@@ -16,7 +16,7 @@
 
 from ducktools.envman.environment_spec import EnvironmentSpec
 
-from prefab_classes import prefab, attribute
+from ducktools.classbuilder.prefab import prefab, attribute
 import pytest
 
 


### PR DESCRIPTION
Replace the now deprecated prefab-classes module with the reimplementation from ducktools-classbuilder.

This involved changing the `save` method and the definition of a catalogue slightly due to the new way excluded fields are handled.