### PR TITLE
WIP: Use UV if it is available - Add locking dependencies to bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,21 @@ applications and scripts written in Python that require additional dependencies.
 If you have a script with external dependencies, you can define them with 
 [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata)
 and run them using
-`python ducktools.pyz run my_script.py`
+`python ducktools.pyz run my_script.py`.
+This is similar to how `uv run my_script.py` or `hatch run my_script.py` work.
 
-If you wish to then provide them to someone else who does not have `ducktools-env` installed
-you can use
+If you wish to then provide them to someone else who does not have `ducktools-env` (or hatch or UV) 
+installed you can use
 `python ducktools.pyz bundle my_script.py`
 in order to create a zipapp version of your script which will self-extract and run in the same
 way.
 
-This makes it easier to send scripts (and eventually applications) that are written in Python
-without having to bundle everything into large platform dependent files and without needing
-anything else installed other than an appropriate Python version.
+This bundle will include `ducktools-env` and the `pip` zipapp in order to bootstrap the unbundling
+process.
+
+This makes it easier to send scripts that are written in Python without having to create 
+large platform dependent files and without needing anything else installed other than an 
+appropriate Python version.
 
 ## How it does this ##
 
@@ -62,7 +66,7 @@ Future goals for this tool:
   * Currently, generating these will probably require `UV` and hence a UV supported platform
   * These should *run* under PIP though, so UV would only be needed for generation
 * Optionally bundle requirements inside the zipapp for use without a connection.
-* Bundle `entry-points` from a wheel into zipapps.
+* Allow bundling of local wheel files unavailable on PyPI
 * Create 'permanent' named environments for stand-alone applications and update them
   * Currently there is a maximum of 2 temporary environments that expire in a day
     (this is due to the pre-release nature of the project, the future defaults will be higher/longer)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Subprocesses:
 * `venv` (via subprocess on python installs)
   * (Might eventually use `virtualenv` as there are python installs without `venv`)
 * `pip` (as a zipapp via subprocess)
+* `uv` where available as a faster installer and for locking dependencies for bundles
 
 PyPI: 
 * `ducktools-classbuilder` (A lazy, faster implementation of the building blocks behind things like dataclasses)
@@ -121,9 +122,3 @@ into a zipapp that will work on the other end with only Python as the requiremen
 based on their `[project.scripts]` and `[project.gui-scripts]`. This is a goal of ducktools.env, 
 except it would build separate zipapps for each script and the apps would share the same cached 
 python environment.
-
-## UV ##
-
-UV may be used in the future as a potential performance boost and to generate lockfiles for
-bundled environments. However, it will not replace `pip` as the primary installer as one goal 
-is that bundled scripts created using this will run anywhere Python can run.

--- a/examples/inline/pep_723_example.py
+++ b/examples/inline/pep_723_example.py
@@ -1,0 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests<3",
+#   "rich",
+# ]
+# ///
+
+import requests
+from rich.pretty import pprint
+
+resp = requests.get("https://peps.python.org/api/peps.json")
+data = resp.json()
+pprint([(k, v["title"]) for k, v in data.items()][:10])

--- a/src/ducktools/env/bundle.py
+++ b/src/ducktools/env/bundle.py
@@ -67,8 +67,17 @@ def create_bundle(
         build_path = Path(build_folder)
         print(f"Building bundle in {build_path!r}")
         print("Copying libraries into build folder")
+        # Don't copy UV - it's platform dependent
+        uv_base_exe = "uv.exe" if sys.platform == "win32" else "uv"
+        uv_pattern = shutil.ignore_patterns(uv_base_exe, f"{uv_base_exe}.version")
+
         # Copy pip and ducktools zipapps into folder
-        shutil.copytree(paths.manager_folder, build_path, dirs_exist_ok=True)
+        shutil.copytree(
+            paths.manager_folder,
+            build_path,
+            ignore=uv_pattern,
+            dirs_exist_ok=True,
+        )
 
         resources = importlib_resources.files("ducktools.env")
 

--- a/src/ducktools/env/bundle.py
+++ b/src/ducktools/env/bundle.py
@@ -114,6 +114,9 @@ def create_bundle(
 
         subprocess.run(pip_command)
 
+        # Get Lock file
+        # uv pip compile -q --universal --no-strip-markers --no-build
+
         print("Copying script to build folder and bundling")
         shutil.copy(script_path, build_path)
 

--- a/src/ducktools/env/bundle.py
+++ b/src/ducktools/env/bundle.py
@@ -65,7 +65,7 @@ def create_bundle(
 
     with paths.build_folder() as build_folder:
         build_path = Path(build_folder)
-        print(f"Building bundle in {build_path!r}")
+        print(f"Building bundle in {build_folder!r}")
         print("Copying libraries into build folder")
         # Don't copy UV - it's platform dependent
         uv_base_exe = "uv.exe" if sys.platform == "win32" else "uv"

--- a/src/ducktools/env/bundle.py
+++ b/src/ducktools/env/bundle.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import importlib_resources
 
 from . import MINIMUM_PYTHON_STR, bootstrap_requires
+from .environment_specs import EnvironmentSpec
 from .platform_paths import ManagedPaths
 from .exceptions import ScriptNameClash
 
@@ -48,6 +49,7 @@ def create_bundle(
     script_file: str,
     output_file: str | None = None,
     paths: ManagedPaths,
+    uv_path: str | None,
     installer_command: list[str],
 ) -> None:
     script_path = Path(script_file)
@@ -100,6 +102,7 @@ def create_bundle(
         pip_command = [
             *installer_command,
             "install",
+            "-q",
             *bootstrap_requires,
             "--python-version",
             MINIMUM_PYTHON_STR,
@@ -110,16 +113,6 @@ def create_bundle(
         ]
 
         subprocess.run(pip_command)
-
-        freeze_command = [
-            *installer_command,
-            "freeze",
-            "--path",
-            vendor_folder,
-        ]
-
-        freeze = subprocess.run(freeze_command, capture_output=True, text=True)
-        (Path(vendor_folder) / "requirements.txt").write_text(freeze.stdout)
 
         print("Copying script to build folder and bundling")
         shutil.copy(script_path, build_path)

--- a/src/ducktools/env/catalogue.py
+++ b/src/ducktools/env/catalogue.py
@@ -452,7 +452,9 @@ class TempCatalogue(BaseCatalogue):
             )
 
             installed_modules = [
-                item.strip() for item in freeze.stdout.split(os.linesep) if item
+                item.strip()
+                for item in freeze.stdout.split("\n")
+                if item
             ]
 
             new_env.installed_modules.extend(installed_modules)

--- a/src/ducktools/env/catalogue.py
+++ b/src/ducktools/env/catalogue.py
@@ -47,7 +47,6 @@ _laz = LazyImporter(
         ModuleImport("subprocess"),
         ModuleImport("hashlib"),
         FromImport("ducktools.pythonfinder", "list_python_installs"),
-        FromImport(".scripts.get_pip", "retrieve_pip"),
     ],
     globs=globals(),
 )

--- a/src/ducktools/env/config.py
+++ b/src/ducktools/env/config.py
@@ -51,6 +51,8 @@ class Config(Prefab, kw_only=True):
     applications_expire: bool = False
     applications_lifetime: float = 28.0
 
+    use_uv: bool = True
+
     @property
     def cache_lifetime_delta(self) -> _timedelta:
         return _timedelta(days=self.cache_lifetime)

--- a/src/ducktools/env/environment_specs.py
+++ b/src/ducktools/env/environment_specs.py
@@ -67,7 +67,7 @@ class SpecType(enum.IntEnum):
     if needed.
     """
     INLINE_METADATA = 1
-    PYPROJECT_METADATA = 2
+    WHEEL_METADATA = 2
 
 
 class EnvironmentDetails(Prefab, kw_only=True):
@@ -77,8 +77,6 @@ class EnvironmentDetails(Prefab, kw_only=True):
     project_name: str | None
     project_owner: str | None
     project_version: str | None
-
-    override_tempenv: bool
 
     @property
     def requires_python_spec(self):
@@ -163,13 +161,11 @@ class EnvironmentSpec:
             version = env_project_table.get("version", None)
             owner = env_project_table.get("owner", None)
 
-        elif self.spec_type == SpecType.PYPROJECT_METADATA:
-            raise EnvironmentError("PyProject spec not implemented")
+        elif self.spec_type == SpecType.WHEEL_METADATA:
+            raise EnvironmentError("Wheel based spec not implemented")
 
         else:
             raise TypeError(f"'spec_type' must be an instance of {SpecType.__name__!r}")
-
-        override_tempenv = data_table.get("override_tempenv", False)
 
         # noinspection PyArgumentList
         return EnvironmentDetails(
@@ -178,7 +174,6 @@ class EnvironmentSpec:
             project_name=project_name,
             project_owner=owner,
             project_version=version,
-            override_tempenv=override_tempenv,
         )
 
     def as_dict(self):

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -168,5 +168,6 @@ class Manager:
             script_file=script_file,
             output_file=output_file,
             paths=self.paths,
-            installer_command=self.install_base_command
+            uv_path=self.retrieve_uv(),
+            installer_command=self.install_base_command,
         )

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -137,7 +137,10 @@ class Manager:
     def get_script_env(self, path):
         spec = EnvironmentSpec.from_script(path)
         env = self.temp_catalogue.find_or_create_env(
-            spec=spec, config=self.config, pip_zipapp=self.retrieve_pip()
+            spec=spec,
+            config=self.config,
+            uv_path=self.retrieve_uv(),
+            installer_command=self.install_base_command,
         )
         return env
 

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -159,4 +159,10 @@ class Manager:
         """Create a zipapp bundle for the provided script file"""
         if not self.is_installed:
             self.install()
-        _laz.create_bundle(script_file=script_file, output_file=output_file, paths=self.paths)
+
+        _laz.create_bundle(
+            script_file=script_file,
+            output_file=output_file,
+            paths=self.paths,
+            installer_command=self.install_base_command
+        )

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -92,7 +92,7 @@ class Manager:
         return _laz.retrieve_pip(paths=self.paths)
 
     def retrieve_uv(self) -> str | None:
-        if use_uv:
+        if self.use_uv:
             return _laz.retrieve_uv(paths=self.paths)
         return None
 

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -26,6 +26,7 @@ import sys
 import os.path
 
 from ducktools.lazyimporter import LazyImporter, FromImport, ModuleImport, MultiFromImport
+from ducktools.classbuilder.prefab import Prefab, attribute
 
 from . import PROJECT_NAME
 from .config import Config, log
@@ -57,20 +58,16 @@ _laz = LazyImporter(
 )
 
 
-class Manager:
-    project_name: str
-    paths: ManagedPaths
-    config: Config
+class Manager(Prefab):
+    project_name: str = PROJECT_NAME
+    config: Config = None
 
-    def __init__(self, project_name=PROJECT_NAME):
-        self.project_name = project_name
+    paths: ManagedPaths = attribute(init=False, repr=False)
+    _temp_catalogue: TempCatalogue | None = attribute(default=None, private=True)
 
+    def __prefab_post_init__(self, config):
         self.paths = ManagedPaths(PROJECT_NAME)
-        self.config = Config.load(self.paths.config_path)
-        self._temp_catalogue = None
-
-    def __repr__(self):
-        return f"{type(self).__name__}(project_name={self.project_name!r})"
+        self.config = Config.load(self.paths.config_path) if config is None else config
 
     @property
     def temp_catalogue(self):

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -61,14 +61,12 @@ class Manager:
     project_name: str
     paths: ManagedPaths
     config: Config
-    use_uv: bool
 
     def __init__(self, project_name=PROJECT_NAME):
         self.project_name = project_name
 
         self.paths = ManagedPaths(PROJECT_NAME)
         self.config = Config.load(self.paths.config_path)
-        self.use_uv = True
         self._temp_catalogue = None
 
     def __repr__(self):
@@ -92,7 +90,7 @@ class Manager:
         return _laz.retrieve_pip(paths=self.paths)
 
     def retrieve_uv(self) -> str | None:
-        if self.use_uv:
+        if self.config.use_uv:
             return _laz.retrieve_uv(paths=self.paths)
         return None
 

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -61,12 +61,14 @@ class Manager:
     project_name: str
     paths: ManagedPaths
     config: Config
+    use_uv: bool
 
     def __init__(self, project_name=PROJECT_NAME):
         self.project_name = project_name
 
         self.paths = ManagedPaths(PROJECT_NAME)
         self.config = Config.load(self.paths.config_path)
+        self.use_uv = True
         self._temp_catalogue = None
 
     def __repr__(self):
@@ -90,7 +92,9 @@ class Manager:
         return _laz.retrieve_pip(paths=self.paths)
 
     def retrieve_uv(self) -> str | None:
-        return _laz.retrieve_uv(paths=self.paths)
+        if use_uv:
+            return _laz.retrieve_uv(paths=self.paths)
+        return None
 
     @property
     def install_base_command(self) -> list[str]:

--- a/src/ducktools/env/platform_paths.py
+++ b/src/ducktools/env/platform_paths.py
@@ -82,7 +82,6 @@ def get_platform_folder(name):
         return os.path.join(USER_FOLDER, f".{name}")
 
 
-
 class ManagedPaths:
     project_name: str
     project_folder: str
@@ -90,6 +89,7 @@ class ManagedPaths:
 
     manager_folder: str
     pip_zipapp: str
+    uv_executable: str
     env_folder: str
 
     application_folder: str  # Not yet used
@@ -109,6 +109,10 @@ class ManagedPaths:
 
         self.manager_folder = os.path.join(self.project_folder, MANAGER_FOLDERNAME)
         self.pip_zipapp = os.path.join(self.manager_folder, "pip.pyz")
+        self.uv_executable = os.path.join(
+            self.manager_folder,
+            "uv.exe" if sys.platform == "win32" else "uv",
+        )
         self.env_folder = os.path.join(self.manager_folder, "ducktools-env")
 
         self.application_folder = os.path.join(self.project_folder, APPLICATION_FOLDERNAME)
@@ -119,13 +123,11 @@ class ManagedPaths:
 
     @staticmethod
     def get_app_version(versionfile):
-
         try:
             with open(versionfile, 'r') as f:
                 ver = f.read()
         except FileNotFoundError:
             return None
-
         return ver
 
     def get_pip_version(self):
@@ -136,6 +138,10 @@ class ManagedPaths:
         version_file = f"{self.env_folder}.version"
         return self.get_app_version(version_file)
 
+    def get_uv_version(self):
+        version_file = f"{self.uv_executable}.version"
+        return self.get_app_version(version_file)
+
     def build_folder(self):
         """
         Get a temporary folder to use for builds
@@ -144,7 +150,7 @@ class ManagedPaths:
         os.makedirs(self.build_base, exist_ok=True)
 
         import tempfile
-        return tempfile.mkdtemp(dir=self.build_base)
+        return tempfile.TemporaryDirectory(dir=self.build_base)
 
 
 if __name__ == "__main__":

--- a/src/ducktools/env/scripts/create_zipapp.py
+++ b/src/ducktools/env/scripts/create_zipapp.py
@@ -25,6 +25,7 @@
 This is the script that builds the inner ducktools-env folder
 and bundles ducktools-env into ducktools.pyz
 """
+import sys
 import os
 import os.path
 import shutil
@@ -136,8 +137,12 @@ def build_zipapp(
                 if p != build_folder_path:
                     shutil.rmtree(p)
 
+        # UV should not be bundled - binary is not cross platform
+        uv_base_exe = "uv.exe" if sys.platform == "win32" else "uv"
+        uv_pattern = shutil.ignore_patterns(uv_base_exe, f"{uv_base_exe}.version")
+
         print("Copying pip.pyz and ducktools-env")
-        shutil.copytree(paths.manager_folder, build_folder, dirs_exist_ok=True)
+        shutil.copytree(paths.manager_folder, build_folder, ignore=uv_pattern, dirs_exist_ok=True)
 
         # Get the paths for modules that need to be copied
         resources = importlib_resources.files("ducktools.env")

--- a/src/ducktools/env/scripts/get_pip.py
+++ b/src/ducktools/env/scripts/get_pip.py
@@ -152,7 +152,5 @@ def retrieve_pip(
         download_pip(paths.pip_zipapp, latest_version=latest_version)
 
         log(f"Pip zipapp installed at {paths.pip_zipapp!r}")
-    else:
-        log("Pip is already up to date")
 
     return paths.pip_zipapp

--- a/src/ducktools/env/scripts/get_uv.py
+++ b/src/ducktools/env/scripts/get_uv.py
@@ -35,42 +35,45 @@ uv_download = "bin/uv.exe" if sys.platform == "win32" else "bin/uv"
 
 
 def retrieve_uv(paths: ManagedPaths) -> str | None:
-    pip_install = retrieve_pip(paths=paths)
-    with paths.build_folder() as build_folder:
+    if os.path.exists(paths.uv_executable):
+        uv_path = paths.uv_executable
+    else:
+        pip_install = retrieve_pip(paths=paths)
+        with paths.build_folder() as build_folder:
 
-        install_folder = os.path.join(build_folder, "uv")
+            install_folder = os.path.join(build_folder, "uv")
 
-        uv_dl = os.path.join(install_folder, uv_download)
+            uv_dl = os.path.join(install_folder, uv_download)
 
-        pip_command = [
-            sys.executable,
-            pip_install,
-            "--disable-pip-version-check",
-            "install",
-            "-q",
-            f"uv{uv_versionspec}",
-            "--only-binary=:all:",
-            "--target",
-            install_folder,
-        ]
+            pip_command = [
+                sys.executable,
+                pip_install,
+                "--disable-pip-version-check",
+                "install",
+                "-q",
+                f"uv{uv_versionspec}",
+                "--only-binary=:all:",
+                "--target",
+                install_folder,
+            ]
 
-        # Download UV with pip - handles getting the correct platform version
-        try:
-            subprocess.run(
-                pip_command,
-                check=True,
-            )
-        except subprocess.CalledProcessError:
-            uv_path = None
-        else:
-            # Copy the executable out of the pip install
-            shutil.copy(uv_dl, paths.uv_executable)
-            uv_path = paths.uv_executable
+            # Download UV with pip - handles getting the correct platform version
+            try:
+                subprocess.run(
+                    pip_command,
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                uv_path = None
+            else:
+                # Copy the executable out of the pip install
+                shutil.copy(uv_dl, paths.uv_executable)
+                uv_path = paths.uv_executable
 
-            version_command = [uv_path, "-V"]
-            version_output = subprocess.run(version_command, capture_output=True, text=True)
-            uv_version = version_output.stdout.split()[1]
-            with open(f"{uv_path}.version", 'w') as ver_file:
-                ver_file.write(uv_version)
+                version_command = [uv_path, "-V"]
+                version_output = subprocess.run(version_command, capture_output=True, text=True)
+                uv_version = version_output.stdout.split()[1]
+                with open(f"{uv_path}.version", 'w') as ver_file:
+                    ver_file.write(uv_version)
 
     return uv_path

--- a/src/ducktools/env/scripts/get_uv.py
+++ b/src/ducktools/env/scripts/get_uv.py
@@ -1,0 +1,76 @@
+# ducktools.env
+# MIT License
+# 
+# Copyright (c) 2024 David C Ellis
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os.path
+import shutil
+import subprocess
+import sys
+
+from ducktools.env.platform_paths import ManagedPaths
+from ducktools.env.scripts.get_pip import retrieve_pip
+
+uv_versionlimit = "<0.5.0"
+
+uv_download = "bin/uv.exe" if sys.platform == "win32" else "bin/uv"
+
+
+def retrieve_uv(paths: ManagedPaths) -> str | None:
+    pip_install = retrieve_pip(paths=paths)
+    with paths.build_folder() as build_folder:
+
+        install_folder = os.path.join(build_folder, "uv")
+
+        uv_dl = os.path.join(install_folder, uv_download)
+
+        pip_command = [
+            sys.executable,
+            pip_install,
+            "--disable-pip-version-check",
+            "install",
+            "-q",
+            f"uv{uv_versionlimit}",
+            "--only-binary=:all:",
+            "--target",
+            install_folder,
+        ]
+
+        # Download UV with pip - handles getting the correct platform version
+        try:
+            subprocess.run(
+                pip_command,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            uv_path = None
+        else:
+            # Copy the executable out of the pip install
+            shutil.copy(uv_dl, paths.uv_executable)
+            uv_path = paths.uv_executable
+
+            version_command = [uv_path, "-V"]
+            version_output = subprocess.run(version_command, capture_output=True, text=True)
+            uv_version = version_output.stdout.split()[1]
+            with open(f"{uv_path}.version", 'w') as ver_file:
+                ver_file.write(uv_version)
+
+    return uv_path

--- a/src/ducktools/env/scripts/get_uv.py
+++ b/src/ducktools/env/scripts/get_uv.py
@@ -29,7 +29,7 @@ import sys
 from ducktools.env.platform_paths import ManagedPaths
 from ducktools.env.scripts.get_pip import retrieve_pip
 
-uv_versionlimit = "<0.5.0"
+uv_versionspec = "~=0.4.0"
 
 uv_download = "bin/uv.exe" if sys.platform == "win32" else "bin/uv"
 
@@ -48,7 +48,7 @@ def retrieve_uv(paths: ManagedPaths) -> str | None:
             "--disable-pip-version-check",
             "install",
             "-q",
-            f"uv{uv_versionlimit}",
+            f"uv{uv_versionspec}",
             "--only-binary=:all:",
             "--target",
             install_folder,

--- a/tests/test_integration/test_build_retrieve.py
+++ b/tests/test_integration/test_build_retrieve.py
@@ -22,7 +22,7 @@ from ducktools.env.environment_specs import EnvironmentSpec, SpecType
 class TestBuildRetrieve:
     def test_build_retrieve(self, testing_catalogue, test_config):
 
-        manager = Manager(PROJECT_NAME)
+        manager = Manager(project_name=PROJECT_NAME)
 
         spec = EnvironmentSpec(
             spec_type=SpecType.INLINE_METADATA,

--- a/tests/test_integration/test_build_retrieve.py
+++ b/tests/test_integration/test_build_retrieve.py
@@ -21,6 +21,7 @@ from ducktools.env.environment_specs import EnvironmentSpec, SpecType
 
 class TestBuildRetrieve:
     def test_build_retrieve(self, testing_catalogue, test_config):
+
         manager = Manager(PROJECT_NAME)
 
         spec = EnvironmentSpec(
@@ -34,7 +35,8 @@ class TestBuildRetrieve:
         real_env = testing_catalogue.find_or_create_env(
             spec=spec,
             config=test_config,
-            pip_zipapp=manager.retrieve_pip()
+            uv_path=manager.retrieve_uv(),
+            installer_command=manager.install_base_command,
         )
 
         assert real_env is not None


### PR DESCRIPTION
If UV can be installed on a platform, install it and use it instead of venv/pip.

It's just so much faster. `pip` is still needed for cross-platform bootstrapping and as a fallback. Tests will eventually need to make sure they run against both.

This also means it's possible to introduce locking to the install and bundling process.

Current plan for how this will work is:

* `ducktools.env bundle ...` will generate a new lockfile by default and include it
* There will be a `--no-lock` option to disable this
* `ducktools.env run` will have an option `--generate-lock` that will make a lockfile and use that to build the env
* `ducktools.env bundle` will gain an option `--use-lockfile` that will bundle the included lockfile
* The internal `run_script` command will gain a lockfile option that will use the lockfile instead of inline dependencies.
