### PR TITLE
Add a script register to launch scripts without them needing to be in the current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ specific script running tool installed.
 
 To aid this, `ducktools.env` provides the `bundle` and `run` commands.
 
-`python ducktools.pyz run my_script.py`
+`ducktools.pyz run my_script.py`
 
 Will run your script much like some of the other script runners.
 
-`python ducktools.pyz bundle my_script.py`
+`ducktools.pyz bundle my_script.py`
 
 Will then generate a zipapp bundle of your script and the required tools to extract and
 execute it in the same way as it is executed via the `run` command.
@@ -64,31 +64,49 @@ Environment data and the application itself will be stored in the following loca
 
 ## Usage ##
 
-Either install the tool from PyPI or simply download the zipapp from github.
+The tool can be used in multiple ways:
 
-If using the tool from PyPI the commands are `python -m ducktools.env <command>` 
-with the zipapp they are `python ducktools.pyz <command>` 
+* Executed from the zipapp
+  * Download from: https://github.com/DavidCEllis/ducktools-env/releases/latest
+  * Run with: `ducktools.pyz <command>`
+* Installed in an environment
+  * Download with `pip` or `uv` in a virtual environment: `pip install ducktools-env`
+  * Run with: `python -m ducktools.env <command>`
+* Accessed via UV tools with `uv tool install`
+  * `uvx ducktools-env <command>`
+
+These examples will use the zipapp command as the base.
 
 Run a script that uses inline script metadata:
 
-`python ducktools.pyz run my_script.py`
+`ducktools.pyz run my_script.py`
 
 Bundle the script into a zipapp:
 
-`python ducktools.pyz bundle my_script.py`
+`ducktools.pyz bundle my_script.py`
 
 Clear the temporary environment cache:
 
-`python ducktools.pyz clear_cache`
+`ducktools.pyz clear_cache`
 
 Clear the full `ducktools/env` install directory:
 
-`python ducktools.pyz clear_cache --full`
+`ducktools.pyz clear_cache --full`
 
 Build the env folder from the installed package 
 (**Generally you should not need to do this from the zipapp**)
 
 `python -m ducktools.env rebuild_env`
+
+### Registering scripts ###
+
+It is also now possible to register scripts with `ducktools-env`.
+
+`ducktools.pyz register path/to/my_script.py`
+
+which can then be run by using the script name without the extension:
+
+`ducktools.pyz run my_script`
 
 ## Locking environments ##
 

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -306,16 +306,16 @@ def main():
         if os.path.exists(args.script_filename):
             manager.run_script(
                 script_path=args.script_filename,
-                lock_path=args.with_lock,
-                generate_lock=args.generate_lock,
                 script_args=args.script_args,
+                generate_lock=args.generate_lock,
+                lock_path=args.with_lock,
             )
         else:
             manager.run_registered_script(
                 script_name=args.script_filename,
                 script_args=args.script_args,
                 generate_lock=args.generate_lock,
-                with_lock=args.with_lock,
+                lock_path=args.with_lock,
             )
 
     elif args.command == "bundle":

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -133,6 +133,22 @@ def get_parser(exit_on_error=True) -> FixedArgumentParser:
         action="store_true"
     )
 
+    # 'register' command and args
+    register_parser = subparsers.add_parser(
+        "register",
+        help="Register scripts to be run by name",
+    )
+    register_parser.add_argument(
+        "script_name",
+        action="store",
+        help="Path to the script to register or name of the script to unregister",
+    )
+    register_parser.add_argument(
+        "--remove",
+        action="store_true",
+        help="Uninstall registered script",
+    )
+
     # 'generate_lock' command and args
     generate_lock_parser = subparsers.add_parser(
         "generate_lock",
@@ -175,7 +191,7 @@ def get_parser(exit_on_error=True) -> FixedArgumentParser:
 
     list_parser = subparsers.add_parser(
         "list",
-        help="List the Python virtual environments managed by ducktools-env",
+        help="List the Python virtual environments and scripts managed by ducktools-env",
     )
 
     list_type_group = list_parser.add_mutually_exclusive_group()
@@ -188,6 +204,11 @@ def get_parser(exit_on_error=True) -> FixedArgumentParser:
         "--app",
         action="store_true",
         help="Only list application environments",
+    )
+    list_type_group.add_argument(
+        "--scripts",
+        action="store_true",
+        help="Only list registered scripts"
     )
 
     delete_parser = subparsers.add_parser(
@@ -280,91 +301,114 @@ def main():
     manager = _laz.Manager(PROJECT_NAME)
 
     if args.command == "run":
-        spec = _laz.EnvironmentSpec.from_script(
-            script_path=args.script_filename
-        )
-        if args.generate_lock:
-            uv_path = manager.retrieve_uv(required=True)
-            lockdata = spec.generate_lockdata(uv_path=uv_path)
-            lock_path = f"{args.script_filename}.lock"
-            with open(lock_path, 'w') as f:
-                f.write(lockdata)
-        elif lock_path := args.with_lock:
-            with open(lock_path, 'r') as f:
-                lockdata = f.read()
-            spec.lockdata = lockdata
+        # Split on existence of the command as a file, if the file exists run it
+        # Otherwise look for it in the registered scripts database
+        if os.path.exists(args.script_filename):
+            manager.run_script(
+                script_path=args.script_filename,
+                lock_path=args.with_lock,
+                generate_lock=args.generate_lock,
+                script_args=args.script_args,
+            )
+        else:
+            manager.run_registered_script(
+                script_name=args.script_filename,
+                script_args=args.script_args,
+                generate_lock=args.generate_lock,
+                with_lock=args.with_lock,
+            )
 
-        manager.run_direct_script(
-            spec=spec,
-            args=args.script_args,
-        )
     elif args.command == "bundle":
-        spec = _laz.EnvironmentSpec.from_script(
-            script_path=args.script_filename
-        )
-        
-        if args.generate_lock:
-            uv_path = manager.retrieve_uv(required=True)
-            spec.generate_lockdata(uv_path=uv_path)
-        elif lock_path := args.with_lock:
-            with open(lock_path, 'r') as f:
-                lockdata = f.read()
-            spec.lockdata = lockdata
-
-        manager.create_bundle(
-            spec=spec,
+        bundle_path = manager.create_bundle(
+            script_path=args.script_filename,
+            with_lock=args.with_lock,
+            generate_lock=args.generate_lock,
             output_file=args.output,
-            compressed=args.compress,
+            compressed=args.compressed,
         )
-    elif args.command == "generate_lock":
-        uv_path = manager.retrieve_uv(required=True)
-        spec = _laz.EnvironmentSpec.from_script(
-            script_path=args.script_filename
-        )
-        lockdata = spec.generate_lockdata(uv_path=uv_path)
+        print(f"Bundle created at '{bundle_path}'")
 
-        out_path = args.output if args.output else f"{args.script_filename}.lock"
-        with open(out_path, "w") as f:
-            f.write(lockdata)
+    elif args.command == "register":
+        if args.remove:
+            manager.remove_registered_script(
+                script_name=args.script_name,
+            )
+        else:
+            manager.run_registered_script(
+                script_path=args.script_name,
+            )
+
+    elif args.command == "generate_lock":
+        lock_path = manager.generate_lockfile(
+            script_path=args.script_filename,
+            lockfile_path=args.output,
+        )
+        print(f"Lockfile generated at '{lock_path}'")
+
     elif args.command == "clear_cache":
         if args.full:
             manager.clear_project_folder()
         else:
             manager.clear_temporary_cache()
+
     elif args.command == "rebuild_env":
         manager.build_env_folder()
         if args.zipapp:
             manager.build_zipapp()
+
     elif args.command == "list":
-        has_envs = False
-        if manager.temp_catalogue.environments and not args.app:
-            has_envs = True
+        has_data = False
+        show_temp = args.temp or not (args.app or args.scripts)
+        show_app = args.app or not (args.scripts or args.temp)
+        show_scripts = args.scripts or not (args.app or args.temp)
+
+        if (envs := manager.temp_catalogue.environments) and show_temp:
+            has_data = True
             print("Temporary Environments")
             print("======================")
             formatted = get_columns(
-                data=manager.temp_catalogue.environments.values(),
+                data=envs.values(),
                 headings=["Name", "Last Used"],
-                attributes=["name", "last_used_simple"]
+                attributes=["name", "last_used_simple"],
             )
             for line in formatted:
                 print(line)
             if not args.temp:
+                # newline if not exclusive
                 print()
 
-        if manager.app_catalogue.environments and not args.temp:
-            has_envs = True
-            print("Application environments")
+        if (envs := manager.app_catalogue.environments) and show_app:
+            has_data = True
+            print("Application Environments")
             print("========================")
             formatted = get_columns(
-                data=manager.app_catalogue.environments.values(),
+                data=envs.values(),
                 headings=["Owner / Name", "Last Used"],
-                attributes=["name", "last_used_simple"]
+                attributes=["name", "last_used_simple"],
             )
             for line in formatted:
                 print(line)
+            if not args.app:
+                # newline if not exclusive
+                print()
 
-        if has_envs is False:
-            print("No environments managed by ducktools-env")
+        if (scripts := manager.script_registry.list_registered_scripts()) and show_scripts:
+            has_data = True
+            print("Registered Scripts")
+            print("==================")
+
+            formatted = get_columns(
+                data=scripts,
+                headings=["Script Name", "Path"],
+                attributes=["name", "path"],
+            )
+            for line in formatted:
+                print(line)
+            print()
+
+        if has_data is False:
+            print("No environments or scripts managed by ducktools-env")
+
     elif args.command == "delete_env":
         envname = args.environment_name
         if envname in manager.temp_catalogue.environments:

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -334,7 +334,7 @@ def main():
                 script_name=args.script_name,
             )
         else:
-            manager.run_registered_script(
+            manager.register_script(
                 script_path=args.script_name,
             )
 

--- a/src/ducktools/env/_lazy_imports.py
+++ b/src/ducktools/env/_lazy_imports.py
@@ -37,6 +37,7 @@ laz = LazyImporter(
         ModuleImport("json"),
         ModuleImport("re"),
         ModuleImport("shutil"),
+        ModuleImport("sqlite3", asname="sql"),
         ModuleImport("subprocess"),
         ModuleImport("tempfile"),
         ModuleImport("warnings"),

--- a/src/ducktools/env/_lazy_imports.py
+++ b/src/ducktools/env/_lazy_imports.py
@@ -37,7 +37,6 @@ laz = LazyImporter(
         ModuleImport("json"),
         ModuleImport("re"),
         ModuleImport("shutil"),
-        ModuleImport("sqlite3", asname="sql"),
         ModuleImport("subprocess"),
         ModuleImport("tempfile"),
         ModuleImport("warnings"),

--- a/src/ducktools/env/bootstrapping/bootstrap.py
+++ b/src/ducktools/env/bootstrapping/bootstrap.py
@@ -105,15 +105,11 @@ def launch_script(script_file, zipapp_path, args, lockdata=None):
         from ducktools.env.manager import Manager
         from ducktools.env.environment_specs import EnvironmentSpec
         manager = Manager(PROJECT_NAME)
-        spec = EnvironmentSpec.from_script(
+        manager.run_bundle(
             script_path=script_file,
+            script_args=args,
             lockdata=lockdata,
-        )
-
-        manager.run_bundled_script(
-            spec=spec,
             zipapp_path=zipapp_path,
-            args=args,
         )
     finally:
         sys.path.pop(0)

--- a/src/ducktools/env/catalogue.py
+++ b/src/ducktools/env/catalogue.py
@@ -28,7 +28,7 @@ from datetime import datetime as _datetime, timedelta as _timedelta
 
 from ducktools.classbuilder.prefab import prefab, attribute
 
-from ._sqlclasses import SQLAttribute, SQLClass
+from ._sqlclasses import SQLAttribute, SQLClass, SQLContext
 from .exceptions import InvalidEnvironmentSpec, VenvBuildError, ApplicationError
 from .environment_specs import EnvironmentSpec
 from .config import Config
@@ -44,21 +44,6 @@ def _datetime_now_iso() -> str:
     as a default factory
     """
     return _datetime.now().isoformat()
-
-
-class SQLContext:
-    def __init__(self, db):
-        self.db = db
-        self.connection = None
-
-    def __enter__(self):
-        self.connection = _laz.sql.connect(self.db)
-        return self.connection
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.connection is not None:
-            self.connection.close()
-            self.connection = None
 
 
 class BaseEnvironment(SQLClass):

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -41,6 +41,7 @@ from .platform_paths import ManagedPaths
 from .catalogue import TemporaryCatalogue, ApplicationCatalogue
 from .environment_specs import EnvironmentSpec
 from .exceptions import UVUnavailableError, InvalidEnvironmentSpec, PythonVersionNotFound
+from .register import RegisterManager, RegisteredScript
 
 from ._lazy_imports import laz as _laz
 from ._logger import log
@@ -53,9 +54,10 @@ class Manager(Prefab):
     paths: ManagedPaths = attribute(init=False, repr=False)
     _temp_catalogue: TemporaryCatalogue | None = attribute(default=None, private=True)
     _app_catalogue: ApplicationCatalogue | None = attribute(default=None, private=True)
+    _script_registry: RegisterManager | None = attribute(default=None, private=True)
 
     def __prefab_post_init__(self, config):
-        self.paths = ManagedPaths(PROJECT_NAME)
+        self.paths = ManagedPaths(self.project_name)
         self.config = Config.load(self.paths.config_path) if config is None else config
 
     @property
@@ -72,6 +74,12 @@ class Manager(Prefab):
         if self._app_catalogue is None:
             self._app_catalogue = ApplicationCatalogue(path=self.paths.application_db)
         return self._app_catalogue
+
+    @property
+    def script_registry(self) -> RegisterManager:
+        if self._script_registry is None:
+            self._script_registry = RegisterManager(path=self.paths.register_db)
+        return self._script_registry
 
     @property
     def is_installed(self):
@@ -187,16 +195,30 @@ class Manager(Prefab):
         # Install the ducktools package
         self.build_env_folder(clear_old_builds=True)
 
-    def clear_temporary_cache(self):
-        # Clear the temporary environment cache
-        log(f"Deleting temporary caches at \"{self.paths.cache_folder}\"")
-        self.temp_catalogue.purge_folder()
+    def _spec_from_script(
+        self,
+        *,
+        script_path: str,
+        lock_path: str | None = None,
+        generate_lock: bool = False,
+    ) -> EnvironmentSpec:
+        """
+        Create a 'spec' file from a script path with lockfile arguments
 
-    def clear_project_folder(self):
-        # Clear the entire ducktools folder
-        root_path = self.paths.project_folder
-        log(f"Deleting full cache at {root_path!r}")
-        _laz.shutil.rmtree(root_path, ignore_errors=True)
+        :param script_path: Path to the original script
+        :param lock_path: Path to either existing lockfile or output path for lockfile
+        :param generate_lock: Generate a new lockfile
+        :return: EnvironmentSpec for the given script with required lock details
+        """
+
+        spec = EnvironmentSpec.from_script(script_path)
+        if generate_lock:
+            spec.generate_lockdata(uv_path=self.retrieve_uv(required=True))
+        elif lock_path:
+            with open(lock_path, 'r') as f:
+                spec.lockdata = f.read()
+
+        return spec
 
     # Script running and bundling commands
     def get_script_env(self, spec: EnvironmentSpec):
@@ -243,62 +265,18 @@ class Manager(Prefab):
                     )
         return env
 
-    def run_bundled_script(
-        self,
-        *,
-        spec: EnvironmentSpec,
-        zipapp_path: str,
-        args: list[str],
-    ):
-        env_vars = {
-            LAUNCH_TYPE_ENVVAR: "BUNDLE",
-            LAUNCH_PATH_ENVVAR: zipapp_path,
-        }
-
-        # If the spec indicates there should be data
-        # include the bundle data folder in the archive
-        if spec.details.data_sources:
-            env_vars[DATA_BUNDLE_ENVVAR] = f"{DATA_BUNDLE_FOLDER}/"
-
-        self.run_script(
-            spec=spec,
-            args=args,
-            env_vars=env_vars,
-        )
-
-    def run_direct_script(
-        self,
-        *,
-        spec: EnvironmentSpec,
-        args: list[str],
-    ):
-        env_vars = {
-            LAUNCH_TYPE_ENVVAR: "SCRIPT",
-            LAUNCH_PATH_ENVVAR: spec.script_path,
-        }
-
-        # Add sources to env variable
-        if sources := spec.details.data_sources:
-            split_char = ";" if sys.platform == "win32" else ":"
-            env_vars[DATA_BUNDLE_ENVVAR] = split_char.join(sources)
-
-        self.run_script(
-            spec=spec,
-            args=args,
-            env_vars=env_vars,
-        )
-
-    def run_script(
+    def _launch_script(
         self,
         *,
         spec: EnvironmentSpec,
         args: list[str],
         env_vars: dict[str, str] | None = None,
     ) -> None:
-        """Execute the provided script file with the given arguments
+        """
+        Execute the provided spec with the given arguments
 
-        :param spec: EnvironmentSpec
-        :param args: arguments to be provided to the script file
+        :param spec: Spec generated from script file
+        :param args: Arguments to pass to the script
         :param env_vars: Environment variables to set
         """
         env = self.get_script_env(spec)
@@ -310,21 +288,134 @@ class Manager(Prefab):
         os.environ.update(env_vars)
         _laz.subprocess.run([env.python_path, spec.script_path, *args])
 
-    def create_bundle(
+    # DO NOT REMOVE #
+    def run_bundled_script(
         self,
         *,
         spec: EnvironmentSpec,
+        zipapp_path: str,
+        args: list[str],
+    ):
+        """
+        OLD BUNDLE SCRIPT - Used directly by bundles made prior to v0.2.1
+        This delegates to the new method but is kept for compatibility.
+        """
+        self.run_bundle(
+            script_path=spec.script_path,
+            script_args=args,
+            lockdata=spec.lockdata,
+            zipapp_path=zipapp_path,
+        )
+
+    def run_bundle(
+        self,
+        *,
+        script_path: str,
+        script_args: list[str],
+        lockdata: str | None,
+        zipapp_path: str,
+    ):
+        """
+        Run a script from a path that has been extracted from a bundle
+
+        :param script_path: Path to the .py script extracted from the bundle
+        :param script_args: Arguments to pass to the script
+        :param lockdata: lockfile data from the bundle if it exists or None
+        :param zipapp_path: Path to the original zipapp
+        """
+        spec = EnvironmentSpec.from_script(
+            script_path=script_path,
+            lockdata=lockdata,
+        )
+
+        env_vars = {
+            LAUNCH_TYPE_ENVVAR: "BUNDLE",
+            LAUNCH_PATH_ENVVAR: zipapp_path,
+        }
+
+        # If the spec indicates there should be data
+        # include the bundle data folder in the archive
+        if spec.details.data_sources:
+            env_vars[DATA_BUNDLE_ENVVAR] = f"{DATA_BUNDLE_FOLDER}/"
+
+        self._launch_script(
+            spec=spec,
+            args=script_args,
+            env_vars=env_vars,
+        )
+
+    def run_script(
+        self,
+        *,
+        script_path: str,
+        script_args: list[str],
+        lock_path: str | None,
+        generate_lock: bool = False,
+    ):
+        """
+        Run script specs from regular .py files
+
+        :param script_path: Path to the script to execute
+        :param script_args: Other arguments to pass to the script
+        :param lock_path: Path to either existing lockfile or output path for lockfile
+        :param generate_lock: Generate a new lockfile
+        """
+        spec = self._spec_from_script(
+            script_path=script_path,
+            lock_path=lock_path,
+            generate_lock=generate_lock,
+        )
+
+        if generate_lock:
+            spec.generate_lockdata(uv_path=self.retrieve_uv(required=True))
+            lock_path = lock_path if lock_path else f"{script_path}.lock"
+            with open(lock_path, 'w') as f:
+                f.write(spec.lockdata)
+
+        env_vars = {
+            LAUNCH_TYPE_ENVVAR: "SCRIPT",
+            LAUNCH_PATH_ENVVAR: spec.script_path,
+        }
+
+        # Add sources to env variable
+        if sources := spec.details.data_sources:
+            split_char = ";" if sys.platform == "win32" else ":"
+            env_vars[DATA_BUNDLE_ENVVAR] = split_char.join(sources)
+
+        self._launch_script(
+            spec=spec,
+            args=script_args,
+            env_vars=env_vars,
+        )
+
+    # Higher level commands - take plain inputs
+    def create_bundle(
+        self,
+        *,
+        script_path: str,
+        with_lock: str | None = None,
+        generate_lock: bool = False,
         output_file: str | None = None,
         compressed: bool = False,
-    ) -> None:
-        """Create a zipapp bundle for the provided script file
+    ) -> str:
+        """
+        Create a zipapp bundle for the provided spec
 
-        :param spec: EnvironmentSpec
+        :param script_path: Script file to bundle
+        :param with_lock: Path to lockfile to use in bundle
+        :param generate_lock: Generate a lockfile when bundling
         :param output_file: output path to zipapp bundle (script_file.pyz default)
         :param compressed: Compress the resulting zipapp
+        :return: Path to the output bundle
         """
         if not self.is_installed or self.install_outdated:
             self.install()
+
+        spec = self._spec_from_script(
+            script_path=script_path,
+            lock_path=with_lock,
+            generate_lock=generate_lock,
+        )
 
         _laz.create_bundle(
             spec=spec,
@@ -333,3 +424,76 @@ class Manager(Prefab):
             installer_command=self.install_base_command(use_uv=False),
             compressed=compressed,
         )
+
+        return output_file
+
+    def generate_lockfile(
+        self,
+        script_path: str,
+        lockfile_path: str | None = None
+    ) -> str:
+        """
+        Generate lockfile data and write the output to a file
+        
+        :param script_path: Path to the source script 
+        :param lockfile_path: Path to the output lockfile
+        :return: Path to the output lockfile
+        """""
+        spec = EnvironmentSpec.from_script(script_path=script_path)
+        spec.generate_lockdata(uv_path=self.retrieve_uv(required=True))
+
+        lockfile_path = lockfile_path if lockfile_path else f"{script_path}.lock"
+
+        with open(lockfile_path, 'w') as f:
+            f.write(spec.lockdata)
+
+        return lockfile_path
+
+    def register_script(self, *, script_path: str):
+        reg = self.script_registry.add_script(script_path)
+        log(f"Registered '{reg.path}' as '{reg.name}'")
+
+    def remove_registered_script(self, *, script_name: str):
+        self.script_registry.remove_script(script_name=script_name)
+        log(f"'{script_name}' is no longer registered.")
+
+    def list_registered_scripts(self) -> list[RegisteredScript]:
+        return self.script_registry.list_registered_scripts()
+
+    def run_registered_script(
+        self,
+        *,
+        script_name: str,
+        script_args: list[str] | None,
+        generate_lock: bool = False,
+        with_lock: str | None = None,
+    ) -> None:
+        row = self.script_registry.retrieve_script(script_name=script_name)
+        script_path = row.path
+
+        spec = EnvironmentSpec.from_script(script_path)
+
+        if generate_lock:
+            lockdata = spec.generate_lockdata(uv_path=self.retrieve_uv(required=True))
+            lock_path = f"{script_path}.lock"
+            with open(lock_path, "w") as f:
+                f.write(lockdata)
+        elif lock_path := with_lock:
+            with open(lock_path, 'r') as f:
+                spec.lockdata = f.read()
+
+        if script_args is None:
+            script_args = []
+
+        self.run_script(spec=spec, script_args=script_args)
+
+    def clear_temporary_cache(self):
+        # Clear the temporary environment cache
+        log(f"Deleting temporary caches at \"{self.paths.cache_folder}\"")
+        self.temp_catalogue.purge_folder()
+
+    def clear_project_folder(self):
+        # Clear the entire ducktools folder
+        root_path = self.paths.project_folder
+        log(f"Deleting full cache at {root_path!r}")
+        _laz.shutil.rmtree(root_path, ignore_errors=True)

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -350,8 +350,8 @@ class Manager(Prefab):
         *,
         script_path: str,
         script_args: list[str],
-        lock_path: str | None,
         generate_lock: bool = False,
+        lock_path: str | None,
     ):
         """
         Run script specs from regular .py files
@@ -464,28 +464,19 @@ class Manager(Prefab):
         self,
         *,
         script_name: str,
-        script_args: list[str] | None,
+        script_args: list[str],
         generate_lock: bool = False,
-        with_lock: str | None = None,
+        lock_path: str | None = None,
     ) -> None:
         row = self.script_registry.retrieve_script(script_name=script_name)
         script_path = row.path
 
-        spec = EnvironmentSpec.from_script(script_path)
-
-        if generate_lock:
-            lockdata = spec.generate_lockdata(uv_path=self.retrieve_uv(required=True))
-            lock_path = f"{script_path}.lock"
-            with open(lock_path, "w") as f:
-                f.write(lockdata)
-        elif lock_path := with_lock:
-            with open(lock_path, 'r') as f:
-                spec.lockdata = f.read()
-
-        if script_args is None:
-            script_args = []
-
-        self.run_script(spec=spec, script_args=script_args)
+        self.run_script(
+            script_path=script_path,
+            script_args=script_args,
+            generate_lock=generate_lock,
+            lock_path=lock_path,
+        )
 
     def clear_temporary_cache(self):
         # Clear the temporary environment cache

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -307,6 +307,7 @@ class Manager(Prefab):
             zipapp_path=zipapp_path,
         )
 
+    # Higher level commands - take plain inputs
     def run_bundle(
         self,
         *,
@@ -388,7 +389,6 @@ class Manager(Prefab):
             env_vars=env_vars,
         )
 
-    # Higher level commands - take plain inputs
     def create_bundle(
         self,
         *,

--- a/src/ducktools/env/platform_paths.py
+++ b/src/ducktools/env/platform_paths.py
@@ -45,6 +45,9 @@ CONFIG_FILENAME = "config.json"
 CATALOGUE_FILENAME = "catalogue.db"
 APPCATALOGUE_FILENAME = "app_catalogue.db"
 
+# Filename for the script register
+REGISTER_FILENAME = "scripts.db"
+
 
 # Store in LOCALAPPDATA for windows, User folder for other operating systems
 if sys.platform == "win32":
@@ -99,6 +102,8 @@ class ManagedPaths:
     cache_folder: str
     cache_db: str
 
+    register_db: str
+
     build_base: str
 
     def __init__(self, project_name="ducktools"):
@@ -122,6 +127,8 @@ class ManagedPaths:
 
         self.cache_folder = os.path.join(self.project_folder, CACHEDENV_FOLDERNAME)
         self.cache_db = os.path.join(self.cache_folder, CATALOGUE_FILENAME)
+
+        self.register_db = os.path.join(self.project_folder, REGISTER_FILENAME)
 
         self.build_base = os.path.join(self.project_folder, "build")
 

--- a/src/ducktools/env/register.py
+++ b/src/ducktools/env/register.py
@@ -20,11 +20,85 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os.path
 
-from _sqlclasses import SQLClass
+from ducktools.classbuilder.prefab import Prefab
+
+from ._lazy_imports import laz as _laz
+from ._sqlclasses import SQLAttribute, SQLClass, SQLContext
+from ._logger import log
 
 
-class ScriptRegister(SQLClass):
-    name: str
+class RegisteredScript(SQLClass):
+    rowid: int = SQLAttribute(default=None, primary_key=True)
+    name: str = SQLAttribute(unique=True)
+    path: str = SQLAttribute(unique=True)
+
+    @classmethod
+    def from_script(cls, relpath):
+        name = os.path.splitext(os.path.basename(relpath))[0]
+        path = os.path.abspath(relpath)
+        return cls(name=name, path=path)
+
+
+class RegisterManager(Prefab, kw_only=True):
     path: str
 
+    @property
+    def connection(self) -> SQLContext:
+        if not os.path.exists(self.path):
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            with SQLContext(self.path) as con:
+                RegisteredScript.create_table(con)
+
+        return SQLContext(self.path)
+
+    def add_script(self, script_path: str) -> RegisteredScript:
+        if not os.path.exists(script_path):
+            raise FileNotFoundError(f"'{script_path}' not found")
+
+        new_row = RegisteredScript.from_script(script_path)
+
+        with self.connection as con:
+            try:
+                new_row.insert_row(con)
+            except _laz.sql.DatabaseError as e:
+                raise RuntimeError(
+                    f"Could not add script: '{script_path}' to the register. SQL Error: {e}"
+                )
+
+        return new_row
+
+    def retrieve_script(self, script_name: str) -> RegisteredScript:
+        with self.connection as con:
+            row_filter = {
+                "name": script_name,
+            }
+            row = RegisteredScript.select_row(con, row_filter)
+
+        if row is None:
+            raise RuntimeError(
+                f"'{script_name}' is not a registered script. "
+                f"Use `python -m ducktools-env list --scripts` to show registered scripts."
+            )
+
+        if not os.path.exists(row.path):
+            self.remove_script(script_name)
+
+            raise RuntimeError(
+                f"'{script_name}' file at '{row.path} does not exist, removed from registry."
+            )
+
+        return row
+
+    def remove_script(self, script_name: str) -> None:
+        row = self.retrieve_script(script_name)
+
+        with self.connection as con:
+            row.delete_row(con)
+
+    def list_registered_scripts(self) -> list[RegisteredScript]:
+        with self.connection as con:
+            rows = RegisteredScript.select_rows(con)
+
+        return rows

--- a/src/ducktools/env/register.py
+++ b/src/ducktools/env/register.py
@@ -26,7 +26,6 @@ from ducktools.classbuilder.prefab import Prefab
 
 from ._lazy_imports import laz as _laz
 from ._sqlclasses import SQLAttribute, SQLClass, SQLContext
-from ._logger import log
 
 
 class RegisteredScript(SQLClass):
@@ -79,13 +78,14 @@ class RegisterManager(Prefab, kw_only=True):
         if row is None:
             raise RuntimeError(
                 f"'{script_name}' is not a registered script. "
-                f"Use `python -m ducktools-env list --scripts` to show registered scripts."
+                f"Use `python -m ducktools.env list --scripts` to show registered scripts."
             )
 
         if not os.path.exists(row.path):
-            self.remove_script(script_name)
+            with self.connection as con:
+                row.delete_row(con)
 
-            raise RuntimeError(
+            raise FileNotFoundError(
                 f"'{script_name}' file at '{row.path} does not exist, removed from registry."
             )
 

--- a/src/ducktools/env/register.py
+++ b/src/ducktools/env/register.py
@@ -1,0 +1,30 @@
+# ducktools.env
+# MIT License
+# 
+# Copyright (c) 2024 David C Ellis
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from _sqlclasses import SQLClass
+
+
+class ScriptRegister(SQLClass):
+    name: str
+    path: str
+

--- a/src/ducktools/env/scripts/get_uv.py
+++ b/src/ducktools/env/scripts/get_uv.py
@@ -29,7 +29,7 @@ from .._lazy_imports import laz as _laz
 from ..platform_paths import ManagedPaths
 
 
-uv_versionspec = "~=0.4.0"
+uv_versionspec = ">=0.4.25"
 
 uv_download = "bin/uv.exe" if sys.platform == "win32" else "bin/uv"
 

--- a/tests/test_get_uv.py
+++ b/tests/test_get_uv.py
@@ -223,7 +223,7 @@ class TestRetrieveUV:
             mock.patch("subprocess.run") as run_mock,
             mock.patch.object(ManagedPaths, "get_uv_version") as uv_ver_mock
         ):
-            uv_ver_mock.return_value = "0.4.6"
+            uv_ver_mock.return_value = "0.4.25"
             exists_mock.return_value = True
             uv_path = get_uv.retrieve_uv(paths=self.paths, reinstall=False)
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,147 @@
+# ducktools.env
+# MIT License
+# 
+# Copyright (c) 2024 David C Ellis
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import os.path
+import sqlite3
+import tempfile
+
+from unittest import mock
+
+import pytest
+
+from ducktools.env._sqlclasses import SQLClass
+from ducktools.env.register import RegisteredScript, RegisterManager
+
+
+@pytest.fixture(scope="function")
+def test_register():
+    base_folder = os.path.join(os.path.dirname(__file__), "testing_data")
+    with tempfile.TemporaryDirectory(dir=base_folder) as tempdir:
+        register_db = os.path.join(tempdir, "register.db")
+        register = RegisterManager(path=register_db)
+        yield register
+
+
+class TestRegisterManager:
+    def test_connection_new(self, test_register):
+        with (
+            mock.patch("os.path.exists", return_value=False) as exists_mock,
+            mock.patch("os.makedirs") as makedirs_mock,
+            mock.patch.object(SQLClass, "create_table") as create_table_mock,
+        ):
+            con = test_register.connection
+
+            assert con.db == test_register.path
+
+            exists_mock.assert_called_with(test_register.path)
+            makedirs_mock.assert_called_with(os.path.dirname(test_register.path), exist_ok=True)
+            create_table_mock.assert_called()
+
+    def test_add_remove_retrieve_script(self, test_register):
+        # Create the table before putting the mock in place
+        with test_register.connection:
+            pass
+
+        script_path = "path/to/script.py"
+        script_name = "script"
+
+        with (
+            mock.patch("os.path.exists", return_value=True),
+            mock.patch("os.path.abspath", side_effect=lambda x: x) as abspath_mock,
+        ):
+            row = test_register.add_script(script_path)
+
+            assert row.name == script_name
+            assert row.path == script_path
+
+            abspath_mock.assert_called_once_with(script_path)
+
+            # Retrieve the row
+            retrieve_row = test_register.retrieve_script(script_name)
+
+            assert retrieve_row == row
+
+            # Delete the row and confirm it is no longer retrievable
+            test_register.remove_script(script_name)
+            with pytest.raises(RuntimeError):
+                test_register.retrieve_script(script_name)
+
+    def test_add_script_not_found(self, test_register):
+        with test_register.connection:
+            with pytest.raises(FileNotFoundError):
+                test_register.add_script("path/to/nonexistent/script.py")
+
+    def test_add_repeated_script(self, test_register):
+        with test_register.connection:
+            pass
+
+        script_path = "path/to/script.py"
+
+        with (
+            mock.patch("os.path.exists", return_value=True),
+            mock.patch("os.path.abspath", side_effect=lambda x: x) as abspath_mock,
+        ):
+            test_register.add_script(script_path)
+
+            with pytest.raises(RuntimeError):
+                test_register.add_script(script_path)
+
+    def test_retrieve_lost_script(self, test_register):
+        # Create the table before putting the mock in place
+        with test_register.connection:
+            pass
+
+        script_path = "path/to/script.py"
+        script_name = "script"
+
+        with (
+            mock.patch("os.path.exists", return_value=True),
+            mock.patch("os.path.abspath", side_effect=lambda x: x) as abspath_mock,
+        ):
+            test_register.add_script(script_path)
+
+        # Now unpatched the script should not exist and the script should error
+        with pytest.raises(FileNotFoundError):
+            test_register.retrieve_script(script_name)
+
+    def test_list_registered_scripts(self, test_register):
+        # Create the table before putting the mock in place
+        with test_register.connection:
+            pass
+
+        script_path = "path/to/script.py"
+        script2_path = "path/to/script2.py"
+        script3_path = "path/to/script3.py"
+
+        with (
+            mock.patch("os.path.exists", return_value=True),
+            mock.patch("os.path.abspath", side_effect=lambda x: x),
+        ):
+            script = test_register.add_script(script_path)
+            script2 = test_register.add_script(script2_path)
+            script3 = test_register.add_script(script3_path)
+
+            scripts = test_register.list_registered_scripts()
+
+            assert scripts == [script, script2, script3]


### PR DESCRIPTION
It's useful to be able to write a script in one place and execute it elsewhere. This provides a basic table mapping script names to their paths.