### PR TITLE
Adds the ability to register scripts under alternate names / add a dtrun alias for ducktools-env run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,47 +66,56 @@ Environment data and the application itself will be stored in the following loca
 
 The tool can be used in multiple ways:
 
+* Installed via `uv tool` (or `pipx`)
+  * `uv tool install ducktools-env`
+  * `ducktools-env <command>`
+  * This adds the `dtrun` shortcut for `ducktools-env run`
 * Executed from the zipapp
   * Download from: https://github.com/DavidCEllis/ducktools-env/releases/latest
   * Run with: `ducktools.pyz <command>`
 * Installed in an environment
   * Download with `pip` or `uv` in a virtual environment: `pip install ducktools-env`
-  * Run with: `python -m ducktools.env <command>`
-* Accessed via UV
+  * Run with: `ducktools-env <command>`
+* Accessed directly via `uvx` with uv
   * `uvx ducktools-env <command>`
 
-These examples will use the zipapp command as the base.
+These examples will use the ducktools-env as the base as if installed via `uv tool` or a similar tool.
 
 Run a script that uses inline script metadata:
 
-`ducktools.pyz run my_script.py`
+`ducktools-env run my_script.py`
+
+If installed via `uv`, `pipx` or `pip` there is an alias `dtrun` for this command. 
+Unlike the full command it does not accept optional arguments and all arguments are passed
+on to the script.
+
+`dtrun my_script.py`
 
 Bundle the script into a zipapp:
 
-`ducktools.pyz bundle my_script.py`
+`ducktools-env bundle my_script.py`
 
 Clear the temporary environment cache:
 
-`ducktools.pyz clear_cache`
+`ducktools-env clear_cache`
 
 Clear the full `ducktools/env` install directory:
 
-`ducktools.pyz clear_cache --full`
+`ducktools-env clear_cache --full`
 
-Build the env folder from the installed package 
-(**Generally you should not need to do this from the zipapp**)
+Build the env folder from the installed package:
 
-`python -m ducktools.env rebuild_env`
+`ducktools-env rebuild_env`
 
 ### Registering scripts ###
 
 It is also now possible to register scripts with `ducktools-env`.
 
-`ducktools.pyz register path/to/my_script.py`
+`ducktools-env register path/to/my_script.py`
 
 which can then be run by using the script name without the extension:
 
-`ducktools.pyz run my_script`
+`ducktools-env run my_script` or `dtrun my_script`
 
 ## Locking environments ##
 
@@ -120,23 +129,26 @@ This generation feature uses `uv` which will be automatically installed.
 
 Create a lockfile without running a script:
 
-`python ducktools.pyz generate_lock my_script.py`
+`ducktools-env generate_lock my_script.py`
 
 Run a script and output the generated lockfile (output as my_script.py.lock):
 
-`python ducktools.pyz run --generate-lock my_script.py`
+`ducktools-env run --generate-lock my_script.py` (--generate-lock does not work with `dtrun`)
 
 Run a script using a pre-generated lockfile:
 
-`python ducktools.pyz run --with-lock my_script.py.lock my_script.py`
+`ducktools-env run --with-lock my_script.py.lock my_script.py`
+
+**If a `my_script.py.lock` file is found for a script it will automatically be used without
+needing to be specified**
 
 Bundle a script and generate a lockfile (that will be bundled):
 
-`python ducktools.pyz bundle --generate-lock my_script.py`
+`ducktools-env bundle --generate-lock my_script.py`
 
 Bundle a script with a pre-generated lockfile:
 
-`python ducktools.pyz bundle --with-lock my_script.py.lock my_script.py`
+`ducktools-env bundle --with-lock my_script.py.lock my_script.py`
 
 **If a `my_script.py.lock` file exists it will automatically be used.**
 
@@ -218,11 +230,11 @@ if __name__ == "__main__":
 
 Existing environments can be listed with the command
 
-`python ducktools.pyz list`
+`ducktools-env list`
 
 and deleted with 
 
-`python ducktools.pyz delete_env <envname>`
+`ducktools-env delete_env <envname>`
 
 where `<envname>` is the `name` of a temporary environment or the combination 
 `owner/name` of an application environment as shown in the list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ testing = ["pytest", "pytest-cov", "coverage-conditional-plugin"]
 
 [project.scripts]
 "ducktools-env" = "ducktools.env.__main__:main"
+"dtrun" = "ducktools.env._run:run"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -139,7 +139,7 @@ def get_parser(exit_on_error=True) -> FixedArgumentParser:
         help="Register scripts to be run by name",
     )
     register_parser.add_argument(
-        "script_name",
+        "script_filename",
         action="store",
         help="Path to the script to register or name of the script to unregister",
     )
@@ -147,6 +147,11 @@ def get_parser(exit_on_error=True) -> FixedArgumentParser:
         "--remove",
         action="store_true",
         help="Uninstall registered script",
+    )
+    register_parser.add_argument(
+        "-n", "--name",
+        action="store",
+        help="Register the script with a different name to the filename"
     )
 
     # 'generate_lock' command and args
@@ -330,12 +335,14 @@ def main():
 
     elif args.command == "register":
         if args.remove:
+            # filename should just be the script name, but it's awkward to change this
             manager.remove_registered_script(
-                script_name=args.script_name,
+                script_name=args.script_filename,
             )
         else:
             manager.register_script(
-                script_path=args.script_name,
+                script_path=args.script_filename,
+                script_name=args.name,
             )
 
     elif args.command == "generate_lock":

--- a/src/ducktools/env/_run.py
+++ b/src/ducktools/env/_run.py
@@ -1,0 +1,55 @@
+# ducktools.env
+# MIT License
+# 
+# Copyright (c) 2024 David C Ellis
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Short implementation of the `dtrun` command.
+
+Unlike ducktools-env run, `dtrun` doesn't take any arguments other than the script name
+and arguments to pass on to the following script.
+
+This means it doesn't need to construct the argument parser as everything is passed
+on to the script being run.
+"""
+import sys
+import os.path
+
+from . import PROJECT_NAME
+from .manager import Manager
+
+
+def run():
+    # First argument is the path to this script
+    _, app, *args = sys.argv
+
+    manager = Manager(PROJECT_NAME)
+
+    if os.path.exists(app):
+        manager.run_script(
+            script_path=app,
+            script_args=args,
+        )
+    else:
+        manager.run_registered_script(
+            script_name=app,
+            script_args=args,
+        )

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -351,7 +351,7 @@ class Manager(Prefab):
         script_path: str,
         script_args: list[str],
         generate_lock: bool = False,
-        lock_path: str | None,
+        lock_path: str | None = None,
     ):
         """
         Run script specs from regular .py files

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -449,8 +449,13 @@ class Manager(Prefab):
 
         return lockfile_path
 
-    def register_script(self, *, script_path: str):
-        reg = self.script_registry.add_script(script_path)
+    def register_script(
+        self,
+        *,
+        script_path: str,
+        script_name: str | None = None,
+    ) -> None:
+        reg = self.script_registry.add_script(script_path, script_name=script_name)
         log(f"Registered '{reg.path}' as '{reg.name}'")
 
     def remove_registered_script(self, *, script_name: str):

--- a/src/ducktools/env/register.py
+++ b/src/ducktools/env/register.py
@@ -34,8 +34,11 @@ class RegisteredScript(SQLClass):
     path: str = SQLAttribute(unique=True)
 
     @classmethod
-    def from_script(cls, relpath):
-        name = os.path.splitext(os.path.basename(relpath))[0]
+    def from_script(cls, relpath: str, script_name: str | None = None):
+        if script_name is None:
+            name = os.path.splitext(os.path.basename(relpath))[0]
+        else:
+            name = script_name
         path = os.path.abspath(relpath)
         return cls(name=name, path=path)
 
@@ -52,11 +55,15 @@ class RegisterManager(Prefab, kw_only=True):
 
         return SQLContext(self.path)
 
-    def add_script(self, script_path: str) -> RegisteredScript:
+    def add_script(
+        self,
+        script_path: str,
+        script_name: str | None = None
+    ) -> RegisteredScript:
         if not os.path.exists(script_path):
             raise FileNotFoundError(f"'{script_path}' not found")
 
-        new_row = RegisteredScript.from_script(script_path)
+        new_row = RegisteredScript.from_script(script_path, script_name=script_name)
 
         with self.connection as con:
             try:


### PR DESCRIPTION
This allows shortening names for commonly run scripts and adds a shorter command for the more frequently used 'run' command.