### PR TITLE
Rename ducktools.pyz to ducktools-env.pyz, improve errors, remove .github folder from sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune .github

--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ The tool can be used in multiple ways:
 * Executed from the zipapp
   * Download from: https://github.com/DavidCEllis/ducktools-env/releases/latest
   * Run with: `ducktools-env.pyz <command>`
+  * The `dtrun.pyz` zipapp is available as a shortcut for `ducktools-env.pyz run`
 * Installed in an environment
   * Download with `pip` or `uv` in a virtual environment: `pip install ducktools-env`
   * Run with: `ducktools-env <command>`
+  * The `dtrun` shortcut is also available
 * Accessed directly via `uvx` with uv
   * `uvx ducktools-env <command>`
+  * No access to the `dtrun` shortcut this way
 
 These examples will use the `ducktools-env` command as the base as if installed via `uv tool` or a similar tool.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The tool can be used in multiple ways:
   * This adds the `dtrun` shortcut for `ducktools-env run`
 * Executed from the zipapp
   * Download from: https://github.com/DavidCEllis/ducktools-env/releases/latest
-  * Run with: `ducktools.pyz <command>`
+  * Run with: `ducktools-env.pyz <command>`
 * Installed in an environment
   * Download with `pip` or `uv` in a virtual environment: `pip install ducktools-env`
   * Run with: `ducktools-env <command>`

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -431,7 +431,7 @@ def delete_env_command(manager, args):
     return 0
 
 
-def main() -> int:
+def main_command() -> int:
     executable_name = os.path.splitext(os.path.basename(sys.executable))[0]
 
     if zipapp_path := globals().get("zipapp_path"):
@@ -485,13 +485,16 @@ def main() -> int:
             raise RuntimeError(f"Invalid Command {args.command!r}")
 
 
-if __name__ == "__main__":
+def main() -> int:
     try:
-        result = main()
+        result = main_command()
     except (RuntimeError, EnvError) as e:
         errors = "\n".join(e.args) + "\n"
         if sys.stderr:
             sys.stderr.write(errors)
-        sys.exit(1)
+        return 1
+    return 0
 
-    sys.exit(result)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -192,7 +192,7 @@ def get_parser(prog, exit_on_error=True) -> FixedArgumentParser:
     create_zipapp_parser.add_argument(
         "--zipapp",
         action="store_true",
-        help="Also create the portable ducktools.pyz zipapp",
+        help="Also create the portable ducktools-env.pyz zipapp",
     )
 
     list_parser = subparsers.add_parser(
@@ -432,8 +432,12 @@ def delete_env_command(manager, args):
 
 
 def main() -> int:
-    if __name__ == "__main__":
-        command = f"{os.path.basename(sys.executable)} -m ducktools.env"
+    executable_name = os.path.splitext(os.path.basename(sys.executable))[0]
+
+    if zipapp_path := globals().get("zipapp_path"):
+        command = f"{executable_name} {zipapp_path}"
+    elif __name__ == "__main__":
+        command = f"{executable_name} -m ducktools.env"
     else:
         command = os.path.basename(sys.argv[0])
 

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -30,6 +30,7 @@ from collections.abc import Callable, Generator, Iterable
 from ducktools.lazyimporter import LazyImporter, FromImport
 
 from ducktools.env import __version__, PROJECT_NAME
+from ducktools.env.exceptions import EnvError
 
 _laz = LazyImporter(
     [
@@ -435,13 +436,13 @@ def main():
             print(f"Environment {envname!r} not found")
     else:
         # Should be unreachable
-        raise ValueError("Invalid command")
+        raise RuntimeError(f"Invalid command {args.command!r}")
 
 
 if __name__ == "__main__":
     try:
         main()
-    except RuntimeError as e:
+    except (RuntimeError, EnvError) as e:
         errors = "\n".join(e.args) + "\n"
         if sys.stderr:
             sys.stderr.write(errors)

--- a/src/ducktools/env/_run.py
+++ b/src/ducktools/env/_run.py
@@ -35,6 +35,7 @@ import os.path
 
 from . import PROJECT_NAME
 from .manager import Manager
+from .exceptions import EnvError
 
 
 def run():
@@ -60,7 +61,7 @@ def run():
                 script_name=app,
                 script_args=args,
             )
-    except RuntimeError as e:
+    except (RuntimeError, EnvError) as e:
         msg = "\n".join(e.args) + "\n"
         if sys.stderr:
             sys.stderr.write(msg)

--- a/src/ducktools/env/bootstrapping/bootstrap.py
+++ b/src/ducktools/env/bootstrapping/bootstrap.py
@@ -22,10 +22,11 @@
 # SOFTWARE.
 
 """
-This script becomes the __main__.py script inside the ducktools.pyz zipapp.
+This script handles shared launch requirements for zipapp bundles and the ducktools-env.pyz zipapp
 """
 from __future__ import annotations
 
+import os
 import os.path
 import sys
 import zipfile
@@ -104,7 +105,7 @@ def launch_script(script_file, zipapp_path, args, lockdata=None):
     try:
         from ducktools.env.manager import Manager
         manager = Manager(project_name=PROJECT_NAME)
-        manager.run_bundle(
+        returncode = manager.run_bundle(
             script_path=script_file,
             script_args=args,
             lockdata=lockdata,
@@ -113,7 +114,16 @@ def launch_script(script_file, zipapp_path, args, lockdata=None):
     finally:
         sys.path.pop(0)
 
+    return returncode
+
 
 def launch_ducktools():
+    zipapp_path = sys.argv[0]
+    init_globals = {"zipapp_path": zipapp_path}
+
     import runpy
-    runpy.run_path(default_paths.env_folder, run_name="__main__")
+    runpy.run_path(
+        default_paths.env_folder,
+        init_globals=init_globals,
+        run_name="__main__"
+    )

--- a/src/ducktools/env/bootstrapping/bootstrap.py
+++ b/src/ducktools/env/bootstrapping/bootstrap.py
@@ -102,28 +102,24 @@ def update_libraries():
 
 def launch_script(script_file, zipapp_path, args, lockdata=None):
     sys.path.insert(0, default_paths.env_folder)
-    try:
-        from ducktools.env.manager import Manager
-        manager = Manager(project_name=PROJECT_NAME)
-        returncode = manager.run_bundle(
-            script_path=script_file,
-            script_args=args,
-            lockdata=lockdata,
-            zipapp_path=zipapp_path,
-        )
-    finally:
-        sys.path.pop(0)
-
+    from ducktools.env.manager import Manager
+    manager = Manager(project_name=PROJECT_NAME)
+    returncode = manager.run_bundle(
+        script_path=script_file,
+        script_args=args,
+        lockdata=lockdata,
+        zipapp_path=zipapp_path,
+    )
     return returncode
 
 
 def launch_ducktools():
-    zipapp_path = sys.argv[0]
-    init_globals = {"zipapp_path": zipapp_path}
+    sys.path.insert(0, default_paths.env_folder)
+    from ducktools.env.__main__ import main
+    return main()
 
-    import runpy
-    runpy.run_path(
-        default_paths.env_folder,
-        init_globals=init_globals,
-        run_name="__main__"
-    )
+
+def launch_dtrun():
+    sys.path.insert(0, default_paths.env_folder)
+    from ducktools.env._run import run
+    return run()

--- a/src/ducktools/env/bootstrapping/bundle_main.py
+++ b/src/ducktools/env/bootstrapping/bundle_main.py
@@ -76,7 +76,7 @@ def main(script_name):
             # Extract the script file to the existing folder
             zf.extract(script_info, path=working_dir)
 
-        launch_script(
+        returncode = launch_script(
             script_file=str(script_dest),
             zipapp_path=zip_path,
             args=sys.argv[1:],
@@ -84,5 +84,7 @@ def main(script_name):
         )
     finally:
         script_dest.unlink()
+
+    sys.exit(returncode)
 
 # BUNDLE CODE TO EXECUTE SCRIPT FOLLOWS

--- a/src/ducktools/env/bootstrapping/zipapp_main.py
+++ b/src/ducktools/env/bootstrapping/zipapp_main.py
@@ -22,8 +22,10 @@
 # SOFTWARE.
 
 """
-This is the bootstrapping script for the ducktools.pyz bundle itself
+This is the bootstrapping script for the ducktools-env.pyz bundle itself
 """
+import sys
+
 from _version_check import version_check  # type: ignore
 version_check()
 
@@ -31,4 +33,6 @@ version_check()
 if __name__ == "__main__":
     from _bootstrap import update_libraries, launch_ducktools  # type: ignore
     update_libraries()
-    launch_ducktools()
+    returncode = launch_ducktools()
+
+    sys.exit(returncode)

--- a/src/ducktools/env/bootstrapping/zipapp_main_dtrun.py
+++ b/src/ducktools/env/bootstrapping/zipapp_main_dtrun.py
@@ -22,49 +22,17 @@
 # SOFTWARE.
 
 """
-Short implementation of the `dtrun` command.
-
-Unlike ducktools-env run, `dtrun` doesn't take any arguments other than the script name
-and arguments to pass on to the following script.
-
-This means it doesn't need to construct the argument parser as everything is passed
-on to the script being run.
+This is the bootstrapping script for the ducktools-env.pyz bundle itself
 """
 import sys
-import os.path
 
-from . import PROJECT_NAME
-from .manager import Manager
-from .exceptions import EnvError
+from _version_check import version_check  # type: ignore
+version_check()
 
 
-def run():
-    # First argument is the path to this script
-    _, app, *args = sys.argv
+if __name__ == "__main__":
+    from _bootstrap import update_libraries, launch_dtrun  # type: ignore
+    update_libraries()
+    returncode = launch_dtrun()
 
-    # This has been invoked by dtrun, but errors should show ducktools-env
-    command = "ducktools-env"
-
-    manager = Manager(
-        project_name=PROJECT_NAME,
-        command=command,
-    )
-
-    try:
-        if os.path.isfile(app):
-            manager.run_script(
-                script_path=app,
-                script_args=args,
-            )
-        else:
-            manager.run_registered_script(
-                script_name=app,
-                script_args=args,
-            )
-    except (RuntimeError, EnvError) as e:
-        msg = "\n".join(e.args) + "\n"
-        if sys.stderr:
-            sys.stderr.write(msg)
-        return 1
-
-    return 0
+    sys.exit(returncode)

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -159,7 +159,7 @@ class Manager(Prefab):
                 break
         else:
             # If no Python was matched try to install a matching python from UV
-            if (uv_path := self.retrieve_uv()) and self.config.uv_install_python:
+            if self.config.uv_install_python and (uv_path := self.retrieve_uv()):
                 uv_pythons = _laz_internal.get_available_pythons(uv_path)
                 matched_python = False
                 for ver in uv_pythons:

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -207,7 +207,7 @@ class Manager(Prefab):
         )
 
     def build_zipapp(self, clear_old_builds=True) -> None:
-        """Build the ducktools.pyz zipapp"""
+        """Build the ducktools-env.pyz zipapp"""
         base_command = [sys.executable, self.retrieve_pip(), "--disable-pip-version-check"]
         _laz_internal.build_zipapp(
             paths=self.paths,

--- a/src/ducktools/env/scripts/create_zipapp.py
+++ b/src/ducktools/env/scripts/create_zipapp.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 """
 This is the script that builds the inner ducktools-env folder
-and bundles ducktools-env into ducktools.pyz
+and bundles ducktools-env into ducktools-env.pyz
 """
 import sys
 import os
@@ -43,10 +43,10 @@ from ducktools.env.platform_paths import ManagedPaths
 
 
 def build_env_folder(
-        *,
-        paths: ManagedPaths,
-        install_base_command: list[str],
-        clear_old_builds=True
+    *,
+    paths: ManagedPaths,
+    install_base_command: list[str],
+    clear_old_builds=True
 ) -> None:
     # Get the full requirements for ducktools-env
     deps = []
@@ -138,12 +138,12 @@ def build_env_folder(
 
 
 def build_zipapp(
-        *,
-        paths: ManagedPaths,
-        install_base_command: list[str],
-        clear_old_builds=True
+    *,
+    paths: ManagedPaths,
+    install_base_command: list[str],
+    clear_old_builds=True
 ) -> None:
-    archive_name = "ducktools.pyz"
+    archive_name = "ducktools-env.pyz"
 
     with paths.build_folder() as build_folder:
 

--- a/src/ducktools/env/scripts/create_zipapp.py
+++ b/src/ducktools/env/scripts/create_zipapp.py
@@ -144,6 +144,7 @@ def build_zipapp(
     clear_old_builds=True
 ) -> None:
     archive_name = "ducktools-env.pyz"
+    dtrun_name = "dtrun.pyz"
 
     with paths.build_folder() as build_folder:
 
@@ -225,5 +226,16 @@ def build_zipapp(
         zipapp.create_archive(
             source=build_folder,
             target=dist_folder / archive_name,
+            interpreter="/usr/bin/env python"
+        )
+
+        print(f"Creating {dtrun_name}")
+        with importlib.resources.as_file(resources) as env_folder:
+            main_dtrun_path = env_folder / "bootstrapping" / "zipapp_main_dtrun.py"
+            shutil.copy(main_dtrun_path, build_path / "__main__.py")
+
+        zipapp.create_archive(
+            source=build_folder,
+            target=dist_folder / dtrun_name,
             interpreter="/usr/bin/env python"
         )

--- a/src/ducktools/env/scripts/get_pip.py
+++ b/src/ducktools/env/scripts/get_pip.py
@@ -25,8 +25,8 @@
 This module handles downloading and installing the `pip.pyz` zipapp if it is outdated
 or not installed.
 
-The pip zipapp will be included in ducktools.pyz builds so this should only be needed
-when building ducktools.pyz or if ducktools-env has been installed via pip.
+The pip zipapp will be included in ducktools-env.pyz builds so this should only be needed
+when building ducktools-env.pyz or if ducktools-env has been installed via pip.
 """
 import os
 import os.path


### PR DESCRIPTION
`ducktools-env run` now tries to pass the error code from the script onwards.