### PR TITLE
Stop KeyboardInterrupt being raised in the parent process

### DIFF
--- a/src/ducktools/env/_lazy_imports.py
+++ b/src/ducktools/env/_lazy_imports.py
@@ -32,6 +32,7 @@ __all__ = [
     "metadata",  # importlib.metadata
     "re",
     "shutil",
+    "signal",
     "sql",
     "subprocess",
     "tempfile",
@@ -66,6 +67,7 @@ with capture_imports(laz):
     import re
     import shutil
     import sqlite3 as sql
+    import signal
     import subprocess
     import tempfile
     import warnings


### PR DESCRIPTION
This temporarily redirects the signal to null in the parent process. The child process will still receive the interrupt.