### PR TITLE
Fix a test that was broken due to a change in ducktools-pythonfinder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ducktools-classbuilder>=0.7.1",
     "ducktools-lazyimporter>=0.7.0",
     "ducktools-scriptmetadata",
-    "ducktools-pythonfinder>=0.6.0",
+    "ducktools-pythonfinder>=0.8.1",
     "tomli; python_version < '3.11'",
     "packaging>=23.2",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ import os.path
 import tempfile
 
 from ducktools.pythonfinder import get_python_installs
-from ducktools.pythonfinder.shared import get_install_details
+from ducktools.pythonfinder.shared import DetailFinder
 
 from ducktools.env.catalogue import TemporaryCatalogue
 from ducktools.env.config import Config
@@ -38,7 +38,8 @@ def available_pythons():
 @pytest.fixture(scope="session")
 def this_python():
     py = sys.executable
-    details = get_install_details(py)
+    finder = DetailFinder()
+    details = finder.get_install_details(py)
     # Pretend PyPy is CPython for tests
     if details.implementation == "pypy":
         details.implementation = "cpython"


### PR DESCRIPTION
When I added the caching behaviour `get_install_details` became a method of `DetailFinder`. I didn't think it was used in `ducktools-env` but it is used for some of the tests.