### PR TITLE
Move the data folder to a more standard location on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ version automatically and use that to build the environment.
 Environment data and the application itself will be stored in the following locations:
 
 * Windows: `%LOCALAPPDATA%\ducktools\env`
-* Linux/Mac/Other: `~/.ducktools/env`
+* Linux/Mac/Other: 
+  * Data: `~/.local/share/ducktools/env`
+  * Config: `~/.config/ducktools/env` (Not yet used)
 
 ## Usage ##
 

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -234,6 +234,10 @@ def get_parser(prog, exit_on_error=True) -> FixedArgumentParser:
             help="migrate old ducktools-env folder"
         )
 
+        migrate_mode = migrate.add_mutually_exclusive_group()
+        migrate_mode.add_argument("--overwrite", action="store_true")
+        migrate_mode.add_argument("--delete", action="store_true")
+
     return parser
 
 
@@ -438,10 +442,17 @@ def delete_env_command(manager, args):
     return 0
 
 
-def migrate_command(manager):
+def migrate_command(manager, args):
     from .platform_paths import PACKAGE_SUBFOLDER, migrate_old_env
     folder_base = os.path.join(manager.project_name, PACKAGE_SUBFOLDER)
-    migrate_old_env(folder_base)
+    if args.overwrite:
+        mode = "overwrite"
+    elif args.delete:
+        mode = "delete"
+    else:
+        mode = "error"
+
+    migrate_old_env(folder_base, mode=mode)
     return 0
 
 
@@ -494,7 +505,7 @@ def main_command() -> int:
         case "delete_env":
             return delete_env_command(manager, args)
         case "migrate":
-            return migrate_command(manager)
+            return migrate_command(manager, args)
         case _:
             raise RuntimeError(f"Invalid Command {args.command!r}")
 

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -227,6 +227,13 @@ def get_parser(prog, exit_on_error=True) -> FixedArgumentParser:
         help="Name of the environment to delete",
     )
 
+    # Temporary migrate argument
+    if sys.platform != "win32":
+        migrate = subparsers.add_parser(
+            "migrate",
+            help="migrate old ducktools-env folder"
+        )
+
     return parser
 
 
@@ -431,6 +438,13 @@ def delete_env_command(manager, args):
     return 0
 
 
+def migrate_command(manager):
+    from .platform_paths import PACKAGE_SUBFOLDER, migrate_old_env
+    folder_base = os.path.join(manager.project_name, PACKAGE_SUBFOLDER)
+    migrate_old_env(folder_base)
+    return 0
+
+
 def main_command() -> int:
     executable_name = os.path.splitext(os.path.basename(sys.executable))[0]
 
@@ -479,6 +493,8 @@ def main_command() -> int:
             return list_command(manager, args)
         case "delete_env":
             return delete_env_command(manager, args)
+        case "migrate":
+            return migrate_command(manager)
         case _:
             raise RuntimeError(f"Invalid Command {args.command!r}")
 

--- a/src/ducktools/env/__main__.py
+++ b/src/ducktools/env/__main__.py
@@ -491,7 +491,7 @@ def main() -> int:
         if sys.stderr:
             sys.stderr.write(errors)
         return 1
-    return 0
+    return result
 
 
 if __name__ == "__main__":

--- a/src/ducktools/env/_run.py
+++ b/src/ducktools/env/_run.py
@@ -39,6 +39,12 @@ from .exceptions import EnvError
 
 
 def run():
+    if len(sys.argv) < 2:
+        # Script path is required
+        sys.stderr.write("usage: dtrun script_filename [script_args ...]\n")
+        sys.stderr.write("dtrun: error: the following arguments are required: script_filename\n")
+        return 1
+
     # First argument is the path to this script
     _, app, *args = sys.argv
 
@@ -52,12 +58,12 @@ def run():
 
     try:
         if os.path.isfile(app):
-            manager.run_script(
+            returncode = manager.run_script(
                 script_path=app,
                 script_args=args,
             )
         else:
-            manager.run_registered_script(
+            returncode = manager.run_registered_script(
                 script_name=app,
                 script_args=args,
             )
@@ -67,4 +73,4 @@ def run():
             sys.stderr.write(msg)
         return 1
 
-    return 0
+    return returncode

--- a/src/ducktools/env/manager.py
+++ b/src/ducktools/env/manager.py
@@ -534,7 +534,7 @@ class Manager(Prefab):
         script_args: list[str],
         generate_lock: bool = False,
         lock_path: str | None = None,
-    ) -> None:
+    ) -> int:
         try:
             row = self.script_registry.retrieve_script(script_name=script_name)
         except ScriptNotFound as e:
@@ -547,7 +547,7 @@ class Manager(Prefab):
 
         script_path = row.path
 
-        self.run_script(
+        return self.run_script(
             script_path=script_path,
             script_args=script_args,
             generate_lock=generate_lock,

--- a/src/ducktools/env/platform_paths.py
+++ b/src/ducktools/env/platform_paths.py
@@ -27,6 +27,7 @@ import sys
 import os
 import os.path
 
+from ._logger import log
 
 class UnsupportedPlatformError(Exception):
     pass
@@ -151,6 +152,13 @@ class ManagedPaths:
         folder_base = os.path.join(self.project_name, PACKAGE_SUBFOLDER)
 
         self.project_folder = get_platform_folder(folder_base)
+
+        if sys.platform != "win32":
+            if os.path.exists(os.path.join(USER_FOLDER, f".{folder_base}")):
+                log(
+                    "Old ducktools-env folder detected, "
+                    "use the migrate subcommand to copy data to the new path."
+                )
 
         self.config_path = os.path.join(
             get_platform_folder(folder_base, config=True),

--- a/src/ducktools/env/platform_paths.py
+++ b/src/ducktools/env/platform_paths.py
@@ -90,7 +90,7 @@ def get_platform_folder(name: str, config: bool = False) -> str:
     return platform_folder
 
 
-def migrate_old_env(name: str):
+def migrate_old_env(name: str, mode="error"):
     if sys.platform != "win32":
         old_folder = os.path.join(USER_FOLDER, f".{name}")
         new_folder = os.path.join(USER_FOLDER, ".local", "share", name)
@@ -98,8 +98,18 @@ def migrate_old_env(name: str):
             print(f"Migrating from {old_folder!r} to {new_folder!r}")
             import shutil
             if os.path.exists(new_folder):
-                print(f"Removing old data folder as new folder detected.")
-                shutil.rmtree(old_folder)
+                if mode == "delete":
+                    print(f"Removing old data folder as new folder detected.")
+                    shutil.rmtree(old_folder)
+                elif mode == "overwrite":
+                    print(f"Overwriting new folder with old folder data")
+                    shutil.rmtree(new_folder)
+                    shutil.move(old_folder, new_folder)
+                else:
+                    raise RuntimeError(
+                        "Error: Both old and new env folders exist.\n"
+                        "Use --delete to remove the old folder or --overwrite to replace the new folder"
+                    )
             else:
                 os.makedirs(os.path.dirname(new_folder), exist_ok=True)
                 shutil.move(old_folder, new_folder)

--- a/src/ducktools/env/platform_paths.py
+++ b/src/ducktools/env/platform_paths.py
@@ -95,13 +95,21 @@ def migrate_old_env(name: str):
         old_folder = os.path.join(USER_FOLDER, f".{name}")
         new_folder = os.path.join(USER_FOLDER, ".local", "share", name)
         if os.path.exists(old_folder):
+            print(f"Migrating from {old_folder!r} to {new_folder!r}")
             import shutil
             if os.path.exists(new_folder):
-                print(f"Removing old data folder as new folder detected: {old_folder!r}")
+                print(f"Removing old data folder as new folder detected.")
                 shutil.rmtree(old_folder)
             else:
                 os.makedirs(os.path.dirname(new_folder), exist_ok=True)
                 shutil.move(old_folder, new_folder)
+                print(f"Moved old data to new folder")
+
+            # Try to remove the old folder, will only succeed if empty
+            try:
+                os.rmdir(os.path.dirname(old_folder))
+            except OSError:
+                pass
 
 
 class ManagedPaths:
@@ -133,9 +141,6 @@ class ManagedPaths:
         folder_base = os.path.join(self.project_name, PACKAGE_SUBFOLDER)
 
         self.project_folder = get_platform_folder(folder_base)
-
-        # Check for the old env folder and migrate on linux/macos
-        migrate_old_env(folder_base)
 
         self.config_path = os.path.join(
             get_platform_folder(folder_base, config=True),

--- a/tests/test_platform_paths.py
+++ b/tests/test_platform_paths.py
@@ -39,7 +39,11 @@ def test_get_platform_folder():
     if sys.platform == "win32":
         assert platform_folder == str(USER_PATH / "demo")
     else:
-        assert platform_folder == str(USER_PATH / ".demo")
+        assert platform_folder == str(USER_PATH / ".local/share/demo")
+
+    if sys.platform != "win32":
+        config_folder = get_platform_folder("demo", config=True)
+        assert config_folder == str(USER_PATH / ".config/demo")
 
 
 class TestManagedPaths:
@@ -52,9 +56,10 @@ class TestManagedPaths:
         # they are not accidentally changed.
 
         project_folder = Path(get_platform_folder(self.project_name)) / "env"
+        config_folder = Path(get_platform_folder(self.project_name, config=True)) / "env"
 
         assert self.paths.project_folder == str(project_folder)
-        assert self.paths.config_path == str(project_folder / "config.json")
+        assert self.paths.config_path == str(config_folder / "config.json")
         assert self.paths.manager_folder == str(project_folder / "lib")
         assert self.paths.pip_zipapp == str(project_folder / "lib" / "pip.pyz")
         assert self.paths.env_folder == str(project_folder / "lib" / "ducktools-env")


### PR DESCRIPTION
This moves the data folder from `~/.ducktools/env` to `~/.local/share/ducktools/env`.

Also resolves the missing error in `dtrun` closing #43 and cleans up a few missing return codes.