### PR TITLE
Correct the record on Pex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,11 @@ and will extract everything into one `~/.shiv` directory unless otherwise specif
 `ducktools-env` will create a separate environment for each unique set of requirements
 for temporary environments by matching specification.
 
-### PEX ###
+### Pex ###
 
 `pex` provides an assortment of related tools for developers alongside a `.pex` bundler.
-It doesn't (to my knowledge) have support for inline script metadata and it makes `.pex` files
-instead of `.pyz` files.
+It supports inline script metadata and running with C extensions. It only supports bundling
+dependencies and does not support `online` installs. It optionally supports embedding Python itself.
 
 ### PyInstaller ###
 


### PR DESCRIPTION
Pex added support for PEP-723 in June of 2024 [here](https://github.com/pex-tool/pex/pull/2436) in version [2.6.0](https://github.com/pex-tool/pex/releases/tag/v2.6.0).

For example:
```console
:; pex --exe examples/application/cowsay_app.py --pip-version 25.0 --sh-boot -o cowsay.pyz --inject-args=--text

:; ./cowsay.pyz Moo!
  ____
| Moo! |
  ====
    \
     \
       ^__^
       (oo)\_______
       (__)\       )\/\
           ||----w |
           ||     ||
```

Support for creating lock files drawing from PEP-723 metadata was added later in https://github.com/pex-tool/pex/pull/2642.