### PR TITLE
Prevent the JSON module from being imported unintentionally

### DIFF
--- a/src/ducktools/env/config.py
+++ b/src/ducktools/env/config.py
@@ -1,18 +1,18 @@
 # ducktools.env
 # MIT License
-# 
+#
 # Copyright (c) 2024 David C Ellis
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -49,7 +49,11 @@ class Config(Prefab, kw_only=True):
         try:
             with open(file_path, 'r') as f:
                 json_data = _laz.json.load(f)
-        except (FileNotFoundError, _laz.json.JSONDecodeError):
+        except FileNotFoundError:
+            new_config = cls()
+            # new_config.save(file_path)
+            return new_config
+        except _laz.json.JSONDecodeError:
             new_config = cls()
             # new_config.save(file_path)
             return new_config


### PR DESCRIPTION
If the config file is not found, previously the import of the json module was triggered as part of the except clause. This separates the except clause so it is no longer triggered accidentally.